### PR TITLE
swap out wcwidth for unicode-width

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,9 @@ homepage = "https://github.com/ctrlcctrlv/justify"
 
 [features]
 default = []
-unicode-width = ["wcwidth"]
 
 [dependencies]
-wcwidth = { version = "1.0.1", optional = true }
+unicode-width = { version = "0.1", optional = true }
 
 [profile.release]
 lto = true

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ intentional.";
 }
 
 #[test]
+#[cfg(feature="unicode-width")]
 fn justify_with_newlines() {
     let settings = Settings { wcwidth: true, .. Settings::default() };
 


### PR DESCRIPTION
Unfortunately, @lucy has decided to yank all versions of `wcwidth`, so the build now fails.

Flip over to `unicode-width`, which seems to be equivalent. Tests are green.